### PR TITLE
feat: Add getCoverageDelta()

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+if ! has nix_direnv_version || ! nix_direnv_version 2.1.0; then
+    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.1.0/direnvrc" "sha256-FAT2R9yYvVg516v3LiogjIc8YfsbWbMM/itqWsm5xTA="
+fi
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ work/
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+.direnv

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Objective (Required)
+Explain this PR's objective, goal.
+
+## Update Summary (Required)
+- List up short descriptions what you have updated.
+- xxx
+
+## Screenshots or movie (Optional)
+Add screenshots or movie to make this PR well understandable.
+
+## Limitations (Optional)
+Indicate limitation if exists.
+
+## References (Optional)
+Share reference links or information if there are.

--- a/README.md
+++ b/README.md
@@ -27,3 +27,13 @@ def lineCoverage = getCoverage('Line');
 ```groovy
 def conditionCoverage = getCoverage('Conditional');
 ```
+
+### Line coverage delta
+```groovy
+def lineCoverageDelta = getCoverageDelta('Line');
+```
+
+### Branch coverage delta
+```groovy
+def conditionCoverageDelta = getCoverageDelta('Conditional');
+```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1649676176,
+        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1652133925,
+        "narHash": "sha256-kfATGChLe9/fQVZkXN9G71JAVMlhePv1qDbaRKklkQs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "51d859cdab1ef58755bd342d45352fc607f5e59b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,18 @@
+{
+  description = "Jenkins plugin dev shell";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+    in {
+      devShell = pkgs.mkShell {
+        nativeBuildInputs = [ pkgs.bashInteractive ];
+        buildInputs = with pkgs; [
+          jdk8
+          maven
+        ];
+      };
+    });
+}

--- a/pom.xml
+++ b/pom.xml
@@ -9,14 +9,14 @@
     </parent>
 
     <properties>
-        <jenkins.version>2.138.4</jenkins.version>
+        <jenkins.version>2.249.1</jenkins.version>
         <java.level>8</java.level>
     </properties>
 
     <groupId>io.jenkins.plugins</groupId>
     <name>Pipeline: Coverage Results</name>
     <artifactId>pipeline-coverage-results</artifactId>
-    <version>0.1.1</version>
+    <version>0.2.0</version>
     <packaging>hpi</packaging>
     <description>Access code coverage results from pipeline</description>
     <url>https://github.com/rguenthe/pipeline-coverage-results-plugin</url>
@@ -32,17 +32,37 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.19</version>
+            <version>1.22</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.19</version>
+            <version>2.23</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>code-coverage-api</artifactId>
-            <version>1.1.0</version>
+            <version>1.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.26</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>1.7.26</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>log4j-over-slf4j</artifactId>
+            <version>1.7.26</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>1.7.26</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/io/jenkins/plugins/pipelinecoverageresults/GetCoverageDeltaStep.java
+++ b/src/main/java/io/jenkins/plugins/pipelinecoverageresults/GetCoverageDeltaStep.java
@@ -1,0 +1,113 @@
+/*
+    The MIT License
+    Copyright (c) 2019 Richard Guenther
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+*/
+
+package io.jenkins.plugins.pipelinecoverageresults;
+
+import hudson.PluginWrapper;
+import hudson.Extension;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+
+import io.jenkins.plugins.coverage.CoverageAction;
+import io.jenkins.plugins.coverage.targets.CoverageElement;
+import io.jenkins.plugins.coverage.targets.Ratio;
+
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.SynchronousStepExecution;
+
+import static jenkins.model.Jenkins.getInstance;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class GetCoverageDeltaStep extends Step {
+
+    private final String element;
+
+    @DataBoundConstructor
+    public GetCoverageDeltaStep(String element) {
+        if (element != null) {
+            this.element = element;
+        } else {
+            this.element = "Line";
+        }
+    }
+
+    @Override
+    public StepExecution start(StepContext context) {
+        return new Execution(context, this.element);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends StepDescriptor {
+
+        @Override
+        public String getFunctionName() {
+            return "getCoverageDelta";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Get coverage delta results";
+        }
+
+        @Override
+        public Set<Class<?>> getRequiredContext() {
+            Set<Class<?>> set = new HashSet<Class<?>>();
+            set.add(Run.class);
+            return set;
+        }
+    }
+
+    private static class Execution extends SynchronousStepExecution<Float> {
+        private static final long serialVersionUID = 1L;
+
+        private float coverageDeltaValue = 0f;
+        private String element;
+
+        Execution(StepContext context, String elem) {
+            super(context);
+            element = elem;
+        }
+
+        @Override
+        protected Float run() throws Exception {
+
+            // Check for Code Coverage API plugin
+            PluginWrapper codeCoverageApiInstalled = getInstance().pluginManager.getPlugin("code-coverage-api");
+            if ((codeCoverageApiInstalled != null) && codeCoverageApiInstalled.isActive()) {
+                CoverageAction coverageAction = getContext().get(Run.class).getAction(CoverageAction.class);
+                CoverageElement coverageElement = CoverageElement.get(element);
+                if ((coverageAction != null) && (coverageElement != null)) {
+                    coverageDeltaValue = coverageAction.getResult().getCoverageDelta(coverageElement);
+                }
+            }
+            return coverageDeltaValue;
+        }
+    }
+}


### PR DESCRIPTION
## Objective (Required)
Add `getCoverageDelta()`, similar to `getCoverage()` but to get the delta coverage compared to the reference build.

## Update Summary (Required)
- Add `getCoverageDelta()`, based on `getCoverage()`
- Update dependencies to a version of `code-coverage-api` which supports `getCoverageDelta()`
- Add NixOS dev shell flake.nix